### PR TITLE
Change alias models to use smaller vertex footprint

### DIFF
--- a/source/modelgen.h
+++ b/source/modelgen.h
@@ -91,20 +91,25 @@ typedef struct dtriangle_s {
 // load this data
 
 typedef struct {
-	byte	v[3];
+	char	v[3]; // Signed because that's what PSP likes
 	byte	lightnormalindex;
 } trivertx_t;
 
 typedef struct {
-	trivertx_t	bboxmin;	// lightnormal isn't used
-	trivertx_t	bboxmax;	// lightnormal isn't used
+	byte	v[3];
+	byte	lightnormalindex;
+} utrivertx_t;
+
+typedef struct {
+	utrivertx_t	bboxmin;	// lightnormal isn't used
+	utrivertx_t	bboxmax;	// lightnormal isn't used
 	char		name[16];	// frame name from grabbing
 } daliasframe_t;
 
 typedef struct {
 	int			numframes;
-	trivertx_t	bboxmin;	// lightnormal isn't used
-	trivertx_t	bboxmax;	// lightnormal isn't used
+	utrivertx_t	bboxmin;	// lightnormal isn't used
+	utrivertx_t	bboxmax;	// lightnormal isn't used
 } daliasgroup_t;
 
 typedef struct {

--- a/source/psp/gu_model.cpp
+++ b/source/psp/gu_model.cpp
@@ -1544,7 +1544,8 @@ int			posenum;
 byte		**player_8bit_texels_tbl;
 byte		*player_8bit_texels;
 
-byte	aliasbboxmins[3], aliasbboxmaxs[3];
+// use signed for PSP friendly coords
+char	aliasbboxmins[3], aliasbboxmaxs[3];
 
 /*
 =================
@@ -1566,8 +1567,8 @@ void * Mod_LoadAliasFrame (void * pin, maliasframedesc_t *frame)
 	for (i=0 ; i<3 ; i++)
 	{
 	// these are byte values, so we don't have to worry about endianness
-		frame->bboxmin.v[i] = pdaliasframe->bboxmin.v[i];
-		frame->bboxmax.v[i] = pdaliasframe->bboxmax.v[i];
+		frame->bboxmin.v[i] = pdaliasframe->bboxmin.v[i] - 128;
+		frame->bboxmax.v[i] = pdaliasframe->bboxmax.v[i] - 128;
 
 		aliasbboxmins[i] = QMIN(aliasbboxmins[i], frame->bboxmin.v[i]);
 		aliasbboxmaxs[i] = QMAX(aliasbboxmaxs[i], frame->bboxmax.v[i]);
@@ -1576,6 +1577,14 @@ void * Mod_LoadAliasFrame (void * pin, maliasframedesc_t *frame)
 	pinframe = (trivertx_t *)(pdaliasframe + 1);
 
 	poseverts[posenum] = pinframe;
+
+	for (i = 0; i < pheader->numverts; i++) {
+		utrivertx_t * unsigned_vert = (utrivertx_t*)&(poseverts[posenum][i]);
+		poseverts[posenum][i].v[0] = unsigned_vert->v[0] - 128;
+		poseverts[posenum][i].v[1] = unsigned_vert->v[1] - 128;
+		poseverts[posenum][i].v[2] = unsigned_vert->v[2] - 128;
+	}
+
 	posenum++;
 
 	pinframe += pheader->numverts;
@@ -1606,8 +1615,8 @@ void *Mod_LoadAliasGroup (void * pin,  maliasframedesc_t *frame)
 	for (i=0 ; i<3 ; i++)
 	{
 	// these are byte values, so we don't have to worry about endianness
-		frame->bboxmin.v[i] = pingroup->bboxmin.v[i];
-		frame->bboxmax.v[i] = pingroup->bboxmax.v[i];
+		frame->bboxmin.v[i] = pingroup->bboxmin.v[i] - 128;
+		frame->bboxmax.v[i] = pingroup->bboxmax.v[i] - 128;
 
 		aliasbboxmins[i] = QMIN(aliasbboxmins[i], frame->bboxmin.v[i]);
 		aliasbboxmaxs[i] = QMAX(aliasbboxmaxs[i], frame->bboxmax.v[i]);
@@ -1624,6 +1633,14 @@ void *Mod_LoadAliasGroup (void * pin,  maliasframedesc_t *frame)
 	for (i=0 ; i<numframes ; i++)
 	{
 		poseverts[posenum] = (trivertx_t *)((daliasframe_t *)ptemp + 1);
+
+		for (int j = 0; j < pheader->numverts; j++) {
+			utrivertx_t * unsigned_vert = (utrivertx_t*)&(poseverts[posenum][j]);
+			poseverts[posenum][j].v[0] = unsigned_vert->v[0] - 128;
+			poseverts[posenum][j].v[1] = unsigned_vert->v[1] - 128;
+			poseverts[posenum][j].v[2] = unsigned_vert->v[2] - 128;
+		}
+
 		posenum++;
 
 		ptemp = (trivertx_t *)((daliasframe_t *)ptemp + 1) + pheader->numverts;
@@ -1955,8 +1972,8 @@ void Mod_LoadAliasModel (model_t *mod, void *buffer)
 	for (i=0 ; i<3 ; i++)
 	{
 		pheader->scale[i] = LittleFloat (pinmodel->scale[i]);
-		pheader->scale_origin[i] = LittleFloat (pinmodel->scale_origin[i]);
-		pheader->eyeposition[i] = LittleFloat (pinmodel->eyeposition[i]);
+		pheader->scale_origin[i] = LittleFloat (pinmodel->scale_origin[i]) + pheader->scale[i] * 128;
+		pheader->eyeposition[i] = LittleFloat (pinmodel->eyeposition[i]) + pheader->scale[i] * 128;
 	}
 
 // load the skins
@@ -1990,8 +2007,8 @@ void Mod_LoadAliasModel (model_t *mod, void *buffer)
 	posenum = 0;
 	pframetype = (daliasframetype_t *)&pintriangles[pheader->numtris];
 
-	aliasbboxmins[0] = aliasbboxmins[1] = aliasbboxmins[2] = 255;
-	aliasbboxmaxs[0] = aliasbboxmaxs[1] = aliasbboxmaxs[2] = 0;
+	aliasbboxmins[0] = aliasbboxmins[1] = aliasbboxmins[2] = 127;
+	aliasbboxmaxs[0] = aliasbboxmaxs[1] = aliasbboxmaxs[2] = -128;
 
 	for (i=0 ; i<numframes ; i++)
 	{

--- a/source/psp/gu_vertex_lighting.h
+++ b/source/psp/gu_vertex_lighting.h
@@ -10,4 +10,5 @@ extern byte anorm_pitch[162];
 extern byte anorm_yaw[162];
 extern byte vlighttable[256][256];
 
+float VLight_GetLightValue(int index, float apitch, float ayaw);
 float VLight_LerpLight(int index1, int index2, float ilerp, float apitch, float ayaw);


### PR DESCRIPTION
These changes have no perceptible visual changes.

UV coords go from 32f to s16, in theory still room to go lower, but because of 32bit alignment for verts, it's hard to get any benefit from it
XYZ coords go from 32f to s8, matches precision that mdl stores them in anyway. However PSP interprets the signed -128 to 127 range as -1 to 1, so scaling had to be changed.

These changes yield a tiny boost in framerates in timedemos and a smaller command buffer alias models in the hunk.
```
before
timedemo 1:
12.8s 75.5fps
timedemo 2:
11.2s 88fps
timedemo 3:
16.3s 66.7fps

after
timedemo 1:
12.4s 78fps
timedemo 2:
11.0s 89fps
timedemo 3:
15.6s 69.7fps
```

In order to boost model performance more, vertex lighting should be replaced with sceGuColor (HIGHLY recommended for nzp), which cuts vertex size by yet another 32 bits, and removes a lot of the per vertex calculation, with frankly minimal visual impact. additionally it could save you some much needed ram, which could buy you opportunities to utilize command buffer for positions too