### PR TITLE
Clipping broad phase

### DIFF
--- a/source/psp/gu_main.cpp
+++ b/source/psp/gu_main.cpp
@@ -164,6 +164,30 @@ qboolean R_CullBox (vec3_t mins, vec3_t maxs)
 	return qfalse;
 }
 
+/*
+=================
+R_FrustumCheck
+
+Returns 0 if box completely inside frustum
+Returns +N with intersected planes count as N
+Returns -1 when completely outside frustum
+=================
+*/
+int R_FrustumCheck (vec3_t mins, vec3_t maxs)
+{
+	int i, res;
+	int intersections = 0;
+	for (i=0 ; i<4 ; i++)
+	{
+		res = BoxOnPlaneSide (mins, maxs, &frustum[i]);
+		if (res == 2) return -1; 
+		if (res == 3) ++intersections;
+	}
+
+	return intersections;
+}
+
+
 // Baker: This is needed even without autoid now
 // due to bbox fix
 /*

--- a/source/psp/gu_model.h
+++ b/source/psp/gu_model.h
@@ -94,6 +94,7 @@ typedef struct texture_s
 #define SURF_DRAWTILED		0x20
 #define SURF_DRAWBACKGROUND	0x40
 #define SURF_UNDERWATER		0x80
+#define SURF_NEEDSCLIPPING	0x100
 
 // !!! if this is changed, it must be changed in asm_draw.h too !!!
 typedef struct

--- a/source/psp/gu_psp.h
+++ b/source/psp/gu_psp.h
@@ -247,6 +247,7 @@ void EmitReflectivePolys (msurface_t *fa);
 void EmitBothSkyLayers (msurface_t *fa);
 void R_DrawSkyChain (msurface_t *s);
 qboolean R_CullBox (vec3_t mins, vec3_t maxs);
+int R_FrustumCheck (vec3_t mins, vec3_t maxs);
 void R_MarkLights (dlight_t *light, int bit, mnode_t *node);
 
 //extern	float	bubblecolor[NUM_DLIGHTTYPES][4];

--- a/source/psp/gu_warp.cpp
+++ b/source/psp/gu_warp.cpp
@@ -312,6 +312,15 @@ void EmitWaterPolys (msurface_t *fa)
 			++dst;
 		}
 
+		// Quick out if clipping broad phase ensures no clipping needed
+		if (!(fa->flags & SURF_NEEDSCLIPPING))
+		{
+			sceGuDrawArray(
+				GU_TRIANGLE_FAN,
+				GU_TEXTURE_32BITF | GU_VERTEX_32BITF,
+				unclipped_vertex_count, 0, unclipped_vertices);
+		}
+
 		// Do these vertices need clipped?
 		if (clipping::is_clipping_required(unclipped_vertices, unclipped_vertex_count))
 		{


### PR DESCRIPTION
Quake already checks each faces bbox if they're outside of frustum, this frustum check can trivially be modified to have return values that tell if the bbox intersects frustum and how many times, as well as if the bbox is completely within view and we know clipping is completely unnecessary. Yields pretty good fps increase in quake timedemos.