### PR TITLE
Use sceGu vertex morphing for alias frame intepolation

### DIFF
--- a/source/psp/gu_mesh.cpp
+++ b/source/psp/gu_mesh.cpp
@@ -224,6 +224,8 @@ static void BuildTris (void)
 		short uv[2];
 	};
 
+	commands[numcommands++] = 0; // Reserve slot for size
+
 	for (i=0 ; i<pheader->numtris ; i++)
 	{
 		// pick an unused triangle and start the trifan
@@ -286,6 +288,8 @@ static void BuildTris (void)
 	}
 
 	commands[numcommands++] = 0;		// end of list marker
+
+	commands[0] = numcommands;
 
 	Con_DPrintf ("%3i tri %3i vert %3i cmd\n", pheader->numtris, numorder, numcommands);
 


### PR DESCRIPTION
Also clean up the model drawing and make the getMemory call to happen just once per mdl instead of once per prim. Not much of a performance implication, maybe a hair better, but interpolation is now basically free so it happens at all distances instead of just close by. Big improvement for torches/flames.