### PR TITLE
Fix building with latest toolchain

### DIFF
--- a/source/host.c
+++ b/source/host.c
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #endif
 #ifdef PSP
 #include "psp/sysmem_module.h"
+#include <psppower.h>
+#include <pspge.h>
+#include <pspsysmem.h>
 #endif
 
 /*
@@ -1059,7 +1062,7 @@ void Host_Init (quakeparms_t *parms)
 
 	int currentCPU = scePowerGetCpuClockFrequency();
 	int currentVRAM = sceGeEdramGetSize();
-    int currentVRAMADD = sceGeEdramGetAddr();
+	int currentVRAMADD = (int) sceGeEdramGetAddr();
 	int currentRAMAVAIL = sceKernelTotalFreeMemSize();
 
 	switch(psp_system_model) {

--- a/source/net_dgrm.c
+++ b/source/net_dgrm.c
@@ -23,7 +23,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "net_dgrm.h"
 
 // This is enables a simple IP banning mechanism
-#ifndef PSP_NETWORKING_CODE
+#ifdef PSP_NETWORKING_CODE
+#include <pspthreadman.h>
+#else
 #define BAN_TEST
 #endif
 

--- a/source/pr_cmds.c
+++ b/source/pr_cmds.c
@@ -313,18 +313,6 @@ void PF_sprint (void)
 	MSG_WriteString (&client->message, s );
 }
 
-void PF_65(void)
-{
-	if (IS_SUPERHOT)
-		PF_centerprint();
-}
-
-void PF_66(void)
-{
-	if (IS_SUPERHOT)
-		PF_centerprint();
-}
-
 /*
 =================
 PF_centerprint
@@ -355,6 +343,17 @@ void PF_centerprint (void)
 	MSG_WriteString (&client->message, s );
 }
 
+void PF_65(void)
+{
+	if (IS_SUPERHOT)
+		PF_centerprint();
+}
+
+void PF_66(void)
+{
+	if (IS_SUPERHOT)
+		PF_centerprint();
+}
 
 /*
 =================

--- a/source/zone.c
+++ b/source/zone.c
@@ -120,7 +120,7 @@ void memcpy_vfpu( void* dst, void* src, unsigned int size )
 	// We use uncached dst to use VFPU writeback and free cpu cache for src only
 	u8* udst8 = (u8*)((u32)dst8 | 0x40000000);
 	// We need the 64 byte aligned address to make sure the dcache is invalidated correctly
-	u8* dst64a = ((u32)dst8&~0x3F);
+	u8* dst64a = (u8*)((u32)dst8&~0x3F);
 	// Invalidate the first line that matches up to the dst start
 	if (size>=64)
 	asm(".set	push\n"					// save assembler option


### PR DESCRIPTION
These changes should not change any of the actual logic. They will just prevent issues while building with the latest toolchain. GCC 14 does not like implicit declarations and missing casts, so that's all this is.